### PR TITLE
Vertex cleanup and renderer

### DIFF
--- a/lib/graphics/src/app.rs
+++ b/lib/graphics/src/app.rs
@@ -10,22 +10,69 @@ use vertex;
 
 pub struct App {
     pub window: window::Window,
-    program: shader::Program,
-    vertices: vertex::VertexBuffers,
+    renderer: Renderer,
 }
 
 impl App {
     pub fn new<T: Into<String>>(width: u32,
                                 height: u32,
                                 title: T,
-                                vertex_source: shader::ShaderSource,
-                                fragment_source: shader::ShaderSource,
-                                vertex_width: u8)
+                                source: RenderingSource)
                                 -> Result<App, Box<error::Error>> {
 
         let window = try!(window::Window::new(width, height, title));
 
         try!(window.make_main());
+
+        let renderer = match source {
+            RenderingSource::ColorRenderingSource => {
+                Renderer::new(shader::SIMPLE_VERTEX_SOURCE,
+                              shader::SIMPLE_FRAGMENT_SOURCE,
+                              5 /* this is the width of a ColorVertex: x, y, red, green, blue */)
+            }
+        };
+
+        return Ok(App {
+            window: window,
+            renderer: renderer,
+        });
+    }
+
+    pub fn draw<V: vertex::VertexSpecable + ?Sized>(&self,
+                                                    rects: &Vec<Box<V>>)
+                                                    -> Result<(), glutin::ContextError> {
+        unsafe {
+            // Clear the screen to red
+            gl::ClearColor(0.9, 0.1, 0.2, 1.0);
+            gl::Clear(gl::COLOR_BUFFER_BIT);
+        }
+
+        self.renderer.draw(rects);
+
+        try!(self.window.swap_buffers());
+        return Ok(());
+    }
+
+    pub fn close(&self) {
+        self.renderer.close();
+    }
+}
+
+pub enum RenderingSource {
+    ColorRenderingSource,
+}
+
+struct Renderer {
+    program: shader::Program,
+    vertices: vertex::VertexBuffers,
+}
+
+impl Renderer {
+    fn new(vertex_source: shader::ShaderSource,
+           fragment_source: shader::ShaderSource,
+           vertex_width: u8)
+           -> Renderer {
+
 
         let vertex_shader = shader::Shader::new(vertex_source, shader::GLShaderEnum::VertexShader);
         let fragment_shader = shader::Shader::new(fragment_source,
@@ -36,29 +83,18 @@ impl App {
 
         program.link_vertex(&vertex_data);
 
-        return Ok(App {
-            window: window,
+        return Renderer {
             program: program,
             vertices: vertex_data,
-        });
+        };
     }
 
-    pub fn draw<V: vertex::VertexSpecable + ?Sized>(&self,
-                                                    rects: &Vec<Box<V>>)
-                                                    -> Result<(), glutin::ContextError> {
+    fn draw<V: vertex::VertexSpecable + ?Sized>(&self, rects: &Vec<Box<V>>) {
         // build and copy the vertex data
         let element_count = self.vertices.gen_vertex_buffers(rects);
         unsafe {
-            // Clear the screen to red
-            gl::ClearColor(0.9, 0.1, 0.2, 1.0);
-            gl::Clear(gl::COLOR_BUFFER_BIT);
-
             gl::DrawElements(gl::TRIANGLES, element_count, gl::UNSIGNED_INT, ptr::null());
-
         }
-
-        try!(self.window.swap_buffers());
-        return Ok(());
     }
 
     pub fn close(&self) {

--- a/lib/graphics/src/app.rs
+++ b/lib/graphics/src/app.rs
@@ -15,15 +15,13 @@ pub struct App {
 }
 
 impl App {
-    pub fn new<T: Into<String>, V: vertex::VertexSpecable + ?Sized>
-        (width: u32,
-         height: u32,
-         title: T,
-         vertex_source: shader::ShaderSource,
-         fragment_source: shader::ShaderSource,
-         vertex_width: u8,
-         rects: &Vec<Box<V>>)
-         -> Result<App, Box<error::Error>> {
+    pub fn new<T: Into<String>>(width: u32,
+                                height: u32,
+                                title: T,
+                                vertex_source: shader::ShaderSource,
+                                fragment_source: shader::ShaderSource,
+                                vertex_width: u8)
+                                -> Result<App, Box<error::Error>> {
 
         let window = try!(window::Window::new(width, height, title));
 
@@ -34,7 +32,7 @@ impl App {
                                                   shader::GLShaderEnum::FragmentShader);
         let program = shader::Program::new(vertex_shader, fragment_shader);
 
-        let vertex_data = vertex::VertexBuffers::new(rects, vertex_width);
+        let vertex_data = vertex::VertexBuffers::new(vertex_width);
 
         program.link_vertex(&vertex_data);
 

--- a/lib/graphics/src/app.rs
+++ b/lib/graphics/src/app.rs
@@ -21,6 +21,7 @@ impl App {
          title: T,
          vertex_source: shader::ShaderSource,
          fragment_source: shader::ShaderSource,
+         vertex_width: u8,
          rects: &Vec<Box<V>>)
          -> Result<App, Box<error::Error>> {
 
@@ -33,7 +34,7 @@ impl App {
                                                   shader::GLShaderEnum::FragmentShader);
         let program = shader::Program::new(vertex_shader, fragment_shader);
 
-        let vertex_data = vertex::VertexBuffers::new(rects);
+        let vertex_data = vertex::VertexBuffers::new(rects, vertex_width);
 
         program.link_vertex(&vertex_data);
 

--- a/lib/graphics/src/lib.rs
+++ b/lib/graphics/src/lib.rs
@@ -8,8 +8,7 @@ mod shader;
 mod shapes;
 
 pub use app::App;
-pub use shader::SIMPLE_VERTEX_SOURCE;
-pub use shader::SIMPLE_FRAGMENT_SOURCE;
+pub use app::RenderingSource;
 pub use shapes::SimpleRect;
 pub use shapes::SimpleTriangle;
 pub use shapes::Updateable;

--- a/lib/graphics/src/shapes.rs
+++ b/lib/graphics/src/shapes.rs
@@ -86,34 +86,34 @@ impl vertex::VertexSpecable for SimpleRect {
         let (top, bottom, left, right) = self.calc_corners();
         let (red, green, blue) = self.color.get_color_floats();
         // top-left, top-right, bottom-left, bottom-right
-        let vertices = vec![vertex::Vertex {
-                                x: left,
-                                y: top,
-                                red: red,
-                                green: green,
-                                blue: blue,
-                            },
-                            vertex::Vertex {
-                                x: right,
-                                y: top,
-                                red: red,
-                                green: green,
-                                blue: blue,
-                            },
-                            vertex::Vertex {
-                                x: right,
-                                y: bottom,
-                                red: red,
-                                green: green,
-                                blue: blue,
-                            },
-                            vertex::Vertex {
-                                x: left,
-                                y: bottom,
-                                red: red,
-                                green: green,
-                                blue: blue,
-                            }];
+        let vertices: Vec<Box<vertex::Vertex>> = vec![Box::new(vertex::ColorVertex {
+                                                          x: left,
+                                                          y: top,
+                                                          red: red,
+                                                          green: green,
+                                                          blue: blue,
+                                                      }),
+                                                      Box::new(vertex::ColorVertex {
+                                                          x: right,
+                                                          y: top,
+                                                          red: red,
+                                                          green: green,
+                                                          blue: blue,
+                                                      }),
+                                                      Box::new(vertex::ColorVertex {
+                                                          x: right,
+                                                          y: bottom,
+                                                          red: red,
+                                                          green: green,
+                                                          blue: blue,
+                                                      }),
+                                                      Box::new(vertex::ColorVertex {
+                                                          x: left,
+                                                          y: bottom,
+                                                          red: red,
+                                                          green: green,
+                                                          blue: blue,
+                                                      })];
 
         // the elements each point to what 3 points make up a single triangle
         // given the elements below and the vertex data, we see the triangles
@@ -196,27 +196,27 @@ impl vertex::VertexSpecable for SimpleTriangle {
         let (top, bottom, left, right, middle) = self.calc_points();
         let (red, green, blue) = self.color.get_color_floats();
         // top-middle, bottom-right, bottom-left
-        let vertices = vec![vertex::Vertex {
-                                x: middle,
-                                y: top,
-                                red: red,
-                                green: green,
-                                blue: blue,
-                            },
-                            vertex::Vertex {
-                                x: right,
-                                y: bottom,
-                                red: red,
-                                green: green,
-                                blue: blue,
-                            },
-                            vertex::Vertex {
-                                x: left,
-                                y: bottom,
-                                red: red,
-                                green: green,
-                                blue: blue,
-                            }];
+        let vertices: Vec<Box<vertex::Vertex>> = vec![Box::new(vertex::ColorVertex {
+                                                          x: middle,
+                                                          y: top,
+                                                          red: red,
+                                                          green: green,
+                                                          blue: blue,
+                                                      }),
+                                                      Box::new(vertex::ColorVertex {
+                                                          x: right,
+                                                          y: bottom,
+                                                          red: red,
+                                                          green: green,
+                                                          blue: blue,
+                                                      }),
+                                                      Box::new(vertex::ColorVertex {
+                                                          x: left,
+                                                          y: bottom,
+                                                          red: red,
+                                                          green: green,
+                                                          blue: blue,
+                                                      })];
 
         // the elements each point to what 3 points make up a single triangle
         // given the elements below and the vertex data, we see the triangle

--- a/lib/graphics/src/vertex.rs
+++ b/lib/graphics/src/vertex.rs
@@ -17,11 +17,15 @@ pub trait VertexSpecable {
 }
 
 pub struct VertexSpecification {
-    pub vertices: Vec<Vertex>,
+    pub vertices: Vec<Box<Vertex>>,
     pub elements: Vec<ElementTriangle>,
 }
 
-pub struct Vertex {
+pub trait Vertex {
+    fn get_vec(&self) -> Vec<GLfloat>;
+}
+
+pub struct ColorVertex {
     pub x: GLfloat,
     pub y: GLfloat,
     pub red: GLfloat,
@@ -29,7 +33,7 @@ pub struct Vertex {
     pub blue: GLfloat,
 }
 
-impl Vertex {
+impl Vertex for ColorVertex {
     fn get_vec(&self) -> Vec<GLfloat> {
         return vec![self.x, self.y, self.red, self.green, self.blue];
     }

--- a/lib/graphics/src/vertex.rs
+++ b/lib/graphics/src/vertex.rs
@@ -9,7 +9,7 @@ pub struct VertexBuffers {
     vao: GLuint,
     vbo: GLuint,
     ebo: GLuint,
-    pub vertex_width: u8,
+    pub vertex_width: u8, // this is the width of the concrete struct that satisfies the Vertex trait
 }
 
 pub trait VertexSpecable {
@@ -60,7 +60,7 @@ impl ElementTriangle {
 }
 
 impl VertexBuffers {
-    pub fn new<V: VertexSpecable + ?Sized>(rects: &Vec<Box<V>>) -> VertexBuffers {
+    pub fn new<V: VertexSpecable + ?Sized>(rects: &Vec<Box<V>>, vertex_width: u8) -> VertexBuffers {
         let mut vao = 0;
         let mut vbo = 0;
         let mut ebo = 0;
@@ -81,7 +81,7 @@ impl VertexBuffers {
             vao: vao,
             vbo: vbo,
             ebo: ebo,
-            vertex_width: 5, /* this is the width of the current definition of a Vertex, the struct above */
+            vertex_width: vertex_width,
         };
 
         v.gen_vertex_buffers(rects);

--- a/lib/graphics/src/vertex.rs
+++ b/lib/graphics/src/vertex.rs
@@ -60,7 +60,7 @@ impl ElementTriangle {
 }
 
 impl VertexBuffers {
-    pub fn new<V: VertexSpecable + ?Sized>(rects: &Vec<Box<V>>, vertex_width: u8) -> VertexBuffers {
+    pub fn new(vertex_width: u8) -> VertexBuffers {
         let mut vao = 0;
         let mut vbo = 0;
         let mut ebo = 0;
@@ -83,8 +83,10 @@ impl VertexBuffers {
             ebo: ebo,
             vertex_width: vertex_width,
         };
-
-        v.gen_vertex_buffers(rects);
+        unsafe {
+            gl::BindBuffer(gl::ARRAY_BUFFER, v.vbo);
+            gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, v.ebo);
+        }
         return v;
     }
 
@@ -106,13 +108,11 @@ impl VertexBuffers {
 
         unsafe {
             // copy the vertex data to the Vertex Buffer Object
-            gl::BindBuffer(gl::ARRAY_BUFFER, self.vbo);
             gl::BufferData(gl::ARRAY_BUFFER,
                            (vertices.len() * mem::size_of::<GLfloat>()) as GLsizeiptr,
                            mem::transmute(&vertices[0]),
                            gl::STATIC_DRAW);
 
-            gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, self.ebo);
             gl::BufferData(gl::ELEMENT_ARRAY_BUFFER,
                            (elements.len() * mem::size_of::<GLint>()) as GLsizeiptr,
                            mem::transmute(&elements[0]),

--- a/programs/sceneplot/src/main.rs
+++ b/programs/sceneplot/src/main.rs
@@ -69,12 +69,11 @@ fn run_app() -> Result<(), Box<std::error::Error>> {
             }
         }
     }
+
     let app = try!(graphics::App::new(600,
                                       600,
                                       "Parallax Client Demo",
-                                      graphics::SIMPLE_VERTEX_SOURCE,
-                                      graphics::SIMPLE_FRAGMENT_SOURCE,
-                                      5 /* this is the width of a ColorVertex: x, y, red, green, blue */));
+                                      graphics::RenderingSource::ColorRenderingSource));
     let mut iteration = 0;
     loop {
         for i in 0..shape_sources.len() {

--- a/programs/sceneplot/src/main.rs
+++ b/programs/sceneplot/src/main.rs
@@ -74,8 +74,7 @@ fn run_app() -> Result<(), Box<std::error::Error>> {
                                       "Parallax Client Demo",
                                       graphics::SIMPLE_VERTEX_SOURCE,
                                       graphics::SIMPLE_FRAGMENT_SOURCE,
-                                      5, // this is the width of a ColorVertex: x, y, red, green, blue
-                                      &rects));
+                                      5 /* this is the width of a ColorVertex: x, y, red, green, blue */));
     let mut iteration = 0;
     loop {
         for i in 0..shape_sources.len() {

--- a/programs/sceneplot/src/main.rs
+++ b/programs/sceneplot/src/main.rs
@@ -74,6 +74,7 @@ fn run_app() -> Result<(), Box<std::error::Error>> {
                                       "Parallax Client Demo",
                                       graphics::SIMPLE_VERTEX_SOURCE,
                                       graphics::SIMPLE_FRAGMENT_SOURCE,
+                                      5, // this is the width of a ColorVertex: x, y, red, green, blue
                                       &rects));
     let mut iteration = 0;
     loop {


### PR DESCRIPTION
The intent of this PR isn't as simple as previous PRs, but it is setup work for the eventual texture shaders that will come. It involves cleanup around vertex setup and representation.

Also introduced is the Renderer struct which will allow for multiple pipelines to be defined at once if we need be.