### PR TITLE
Color vertex and pipeline cleanups

### DIFF
--- a/lib/graphics/src/lib.rs
+++ b/lib/graphics/src/lib.rs
@@ -17,4 +17,5 @@ pub use shapes::Updateable;
 pub use vertex::VertexSpecable;
 pub use vertex::VertexSpecification;
 pub use vertex::Vertex;
+pub use vertex::ColorVertex;
 pub use vertex::ElementTriangle;

--- a/lib/graphics/src/shader_source.rs
+++ b/lib/graphics/src/shader_source.rs
@@ -47,6 +47,7 @@ pub struct VertexAttribute {
     pub stride: GLsizei,
 }
 
+// Color Pipeline Source Definition
 pub fn color_pipeline_source() -> RenderingPipelineSource {
     return RenderingPipelineSource {
         vertex_glsl: GLVertexShader { glsl: COLOR_VS_GLSL },


### PR DESCRIPTION
ColorVertex will be useful if things outside of the graphics module want to build their own entities that can be draw. The comment will help denote where pipeline definitions start, when we have more it will be especially useful.