### PR TITLE
Mandelbrot texture

### DIFF
--- a/lib/graphics/src/app.rs
+++ b/lib/graphics/src/app.rs
@@ -6,6 +6,7 @@ use std::ptr;
 
 use program;
 use shader_source;
+use texture;
 use vertex;
 use window;
 
@@ -28,6 +29,11 @@ impl App {
         let renderer = match source {
             RenderingSource::ColorRenderingSource => {
                 Renderer::new(shader_source::color_pipeline_source())
+            }
+            RenderingSource::TextureRenderingSource { tex_def } => {
+                let r = Renderer::new(shader_source::texture_pipeline_source());
+                texture::texture_load(r.program.get_addr(), tex_def);
+                r
             }
         };
 
@@ -63,6 +69,7 @@ impl App {
 
 pub enum RenderingSource {
     ColorRenderingSource,
+    TextureRenderingSource { tex_def: texture::TextureSetupDefinition, },
 }
 
 struct Renderer {

--- a/lib/graphics/src/lib.rs
+++ b/lib/graphics/src/lib.rs
@@ -6,6 +6,7 @@ mod program;
 mod shader;
 mod shader_source;
 mod shapes;
+mod texture;
 mod vertex;
 mod window;
 
@@ -14,8 +15,10 @@ pub use app::RenderingSource;
 pub use shapes::SimpleRect;
 pub use shapes::SimpleTriangle;
 pub use shapes::Updateable;
+pub use texture::TextureSetupDefinition;
 pub use vertex::VertexSpecable;
 pub use vertex::VertexSpecification;
 pub use vertex::Vertex;
 pub use vertex::ColorVertex;
+pub use vertex::TextureVertex;
 pub use vertex::ElementTriangle;

--- a/lib/graphics/src/program.rs
+++ b/lib/graphics/src/program.rs
@@ -90,6 +90,10 @@ impl Program {
         return vertex_attr.stride as usize;
     }
 
+    pub fn get_addr(&self) -> GLuint {
+        return self.addr;
+    }
+
     pub fn close(&self) {
         self.vertex_shader.close();
         self.fragment_shader.close();

--- a/lib/graphics/src/shader_source.rs
+++ b/lib/graphics/src/shader_source.rs
@@ -79,3 +79,37 @@ const COLOR_FS_GLSL: &'static str = r#"#version 150
     void main() {
        out_color = vec4(attr_color, 1.0);
     }"#;
+
+// Texture Pipeline Source Definition
+pub fn texture_pipeline_source() -> RenderingPipelineSource {
+    return RenderingPipelineSource {
+        vertex_glsl: GLVertexShader { glsl: TEX_VS_GLSL },
+        fragment_glsl: GLFragmentShader { glsl: TEX_FS_GLSL },
+        all_vertex_attrs: vec![VertexAttribute {
+                                   var_name: "position",
+                                   stride: 2,
+                               },
+                               VertexAttribute {
+                                   var_name: "texcoord",
+                                   stride: 2,
+                               }],
+        vertex_width: 4, // this is the width of a TexVertex: x, y, tex_x, tex_y
+    };
+}
+
+const TEX_VS_GLSL: &'static str = r#"#version 150
+    in vec2 position;
+    in vec2 texcoord;
+    out vec2 attr_texcoord;
+    void main() {
+       attr_texcoord = texcoord;
+       gl_Position = vec4(position, 0.0, 1.0);
+    }"#;
+
+const TEX_FS_GLSL: &'static str = r#"#version 150
+    in vec2 attr_texcoord;
+    uniform sampler2D tex_sample;
+    out vec4 out_color;
+    void main() {
+       out_color = texture(tex_sample, attr_texcoord);
+    }"#;

--- a/lib/graphics/src/texture.rs
+++ b/lib/graphics/src/texture.rs
@@ -1,0 +1,42 @@
+extern crate gl;
+
+use std::ffi::CString;
+use std::mem;
+
+use gl::types::*;
+
+pub struct TextureSetupDefinition {
+    pub width: u32,
+    pub height: u32,
+    pub data: Vec<u8>,
+}
+
+pub fn texture_load(program: GLuint, tex_def: TextureSetupDefinition) {
+    unsafe {
+        let mut texture = mem::uninitialized();
+        gl::GenTextures(1, &mut texture);
+
+        gl::BindTexture(gl::TEXTURE_2D, texture);
+        gl::TexImage2D(gl::TEXTURE_2D,
+                       0,
+                       gl::RGBA as GLint, // GLint internalFormat,
+                       tex_def.width as i32,
+                       tex_def.height as i32,
+                       0,
+                       gl::RGBA as GLenum, // GLenum format,
+                       gl::UNSIGNED_BYTE, // GLenum type,
+                       tex_def.data.as_slice().as_ptr() as *const _);
+        gl::Uniform1i(gl::GetUniformLocation(program,
+                                             CString::new("tex_sample").unwrap().as_ptr()),
+                      0);
+
+        gl::TexParameteri(gl::TEXTURE_2D,
+                          gl::TEXTURE_WRAP_S,
+                          gl::CLAMP_TO_EDGE as GLint);
+        gl::TexParameteri(gl::TEXTURE_2D,
+                          gl::TEXTURE_WRAP_T,
+                          gl::CLAMP_TO_EDGE as GLint);
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR as GLint);
+        gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR as GLint);
+    }
+}

--- a/lib/graphics/src/vertex.rs
+++ b/lib/graphics/src/vertex.rs
@@ -39,6 +39,19 @@ impl Vertex for ColorVertex {
     }
 }
 
+pub struct TextureVertex {
+    pub x: GLfloat,
+    pub y: GLfloat,
+    pub tex_x: GLfloat,
+    pub tex_y: GLfloat,
+}
+
+impl Vertex for TextureVertex {
+    fn get_vec(&self) -> Vec<GLfloat> {
+        return vec![self.x, self.y, self.tex_x, self.tex_y];
+    }
+}
+
 pub struct ElementTriangle {
     pub p1: GLint,
     pub p2: GLint,

--- a/programs/mandlebrotviewer/Cargo.toml
+++ b/programs/mandlebrotviewer/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 authors = ["Quinten Palmer <quintenpalmer@gmail.com>"]
 
 [dependencies]
+graphics = {path = "../../lib/graphics"}
 mandelbrot = {path = "../../lib/mandelbrot"}


### PR DESCRIPTION
This commit has two main pieces:
* Support for textures, instead of just colors for vertices to map their pixels for colors from
* Use of said texture support to display the mandelbrot set in an App, as a second way of running the `mandelbrotviewer`.