### PR TITLE
Prefer `use` over `extern crate` outside of lib/mod/main

### DIFF
--- a/lib/graphics/src/app.rs
+++ b/lib/graphics/src/app.rs
@@ -1,5 +1,5 @@
-extern crate gl;
-extern crate glutin;
+use gl;
+use glutin;
 
 use std::error;
 use std::ptr;

--- a/lib/graphics/src/program.rs
+++ b/lib/graphics/src/program.rs
@@ -1,4 +1,4 @@
-extern crate gl;
+use gl;
 
 use std::ffi::CString;
 use std::mem;

--- a/lib/graphics/src/shader.rs
+++ b/lib/graphics/src/shader.rs
@@ -1,4 +1,4 @@
-extern crate gl;
+use gl;
 
 use std::ffi::CString;
 use std::ptr;

--- a/lib/graphics/src/shader_source.rs
+++ b/lib/graphics/src/shader_source.rs
@@ -1,4 +1,4 @@
-extern crate gl;
+use gl;
 
 use gl::types::*;
 

--- a/lib/graphics/src/texture.rs
+++ b/lib/graphics/src/texture.rs
@@ -1,4 +1,4 @@
-extern crate gl;
+use gl;
 
 use std::ffi::CString;
 use std::mem;

--- a/lib/graphics/src/vertex.rs
+++ b/lib/graphics/src/vertex.rs
@@ -1,4 +1,4 @@
-extern crate gl;
+use gl;
 
 use gl::types::*;
 

--- a/lib/graphics/src/window.rs
+++ b/lib/graphics/src/window.rs
@@ -1,5 +1,5 @@
-extern crate gl;
-extern crate glutin;
+use gl;
+use glutin;
 
 pub struct Window {
     window: glutin::Window,

--- a/lib/mandelbrot/src/color_calc.rs
+++ b/lib/mandelbrot/src/color_calc.rs
@@ -1,5 +1,3 @@
-extern crate num;
-
 use num::rational::Ratio;
 
 pub struct SimpleColor {

--- a/lib/mandelbrot/src/eq.rs
+++ b/lib/mandelbrot/src/eq.rs
@@ -1,5 +1,3 @@
-extern crate num;
-
 use num::complex::Complex64;
 
 pub fn mandelbrot_divergence(x: f64, y: f64, iterations: u32) -> Result<(), u32> {

--- a/lib/mandelbrot/src/fileformat.rs
+++ b/lib/mandelbrot/src/fileformat.rs
@@ -1,5 +1,4 @@
-extern crate csv;
-extern crate rustc_serialize;
+use csv;
 
 use std::error;
 use std::fmt;

--- a/lib/mandelbrot/src/image_create.rs
+++ b/lib/mandelbrot/src/image_create.rs
@@ -1,4 +1,4 @@
-extern crate image;
+use image;
 
 use std::error;
 use std::fs;

--- a/lib/sceneplotlib/src/fileformat/shapesource.rs
+++ b/lib/sceneplotlib/src/fileformat/shapesource.rs
@@ -1,10 +1,8 @@
-extern crate csv;
-extern crate rustc_serialize;
-
-use types;
-
+use csv;
 use rustc_serialize::Decodable;
 use rustc_serialize::Decoder;
+
+use types;
 
 pub enum ShapeType {
     Rect,

--- a/lib/sceneplotlib/src/types/mod.rs
+++ b/lib/sceneplotlib/src/types/mod.rs
@@ -1,5 +1,3 @@
-extern crate rustc_serialize;
-
 use rustc_serialize::Decodable;
 use rustc_serialize::Decoder;
 

--- a/programs/mandlebrotviewer/src/main.rs
+++ b/programs/mandlebrotviewer/src/main.rs
@@ -1,5 +1,5 @@
-extern crate mandelbrot;
 extern crate graphics;
+extern crate mandelbrot;
 
 use std::env;
 use std::error;


### PR DESCRIPTION
Including cleanups around the warnings that some `use`s are never used,
and ordering as well.